### PR TITLE
Upgrade Scripts

### DIFF
--- a/Booktracker/Program.cs
+++ b/Booktracker/Program.cs
@@ -11,7 +11,7 @@ namespace bookTrackerApi {
         
         public static void Main(string[] args) {
             DB.InitiateDatabase();
-            DB.initiateConnection();
+            //DB.initiateConnection();
             var builder = WebApplication.CreateBuilder(args);
             builder.Services.AddCors();
 
@@ -52,7 +52,7 @@ namespace bookTrackerApi {
             ChallengeDB.storeChallenges();
 
             Upgrades.EntryPoint.HandleUpgrades();
-            
+
             app.Run();
         }
 

--- a/Booktracker/Program.cs
+++ b/Booktracker/Program.cs
@@ -51,6 +51,8 @@ namespace bookTrackerApi {
             
             ChallengeDB.storeChallenges();
 
+            Upgrades.EntryPoint.HandleUpgrades();
+            
             app.Run();
         }
 

--- a/Booktracker/Program.cs
+++ b/Booktracker/Program.cs
@@ -48,6 +48,7 @@ namespace bookTrackerApi {
             ChallengeEndpoints.configure(app);
             EventEndpoints.configure(app);
             ProgressEndpoints.configure(app);
+            Upgrades.UpgradeEndpoints.Configure(app);
             
             ChallengeDB.storeChallenges();
 

--- a/Booktracker/Upgrade/EntryPoint.cs
+++ b/Booktracker/Upgrade/EntryPoint.cs
@@ -41,18 +41,7 @@ namespace bookTrackerApi.Upgrades {
             string pathToLog;
 
             switch (title) {
-                case "Test upgrade script":
-                    if (!runScript) {
-                        return "found";
-                    }
-                    pathToLog = "external/log/log.txt";
-                    break;
-                case "A different upgrade script":
-                    if (!runScript) {
-                        return "found";
-                    }
-                    pathToLog = "external/log/log.txt";
-                    break;
+                
                 default:
                     return "notFound";
             }

--- a/Booktracker/Upgrade/EntryPoint.cs
+++ b/Booktracker/Upgrade/EntryPoint.cs
@@ -15,9 +15,12 @@ namespace bookTrackerApi.Upgrades {
                 if (script == null) {
                     continue;
                 }
+                if (ScriptFinder(script.Title, false) != "found") {
+                    continue;
+                }
                 string? backupPath = Utilities.CreateBackup(script);
 
-                string logPath = ScriptFinder(script.Title);
+                string logPath = ScriptFinder(script.Title, true);
                 if (logPath == "notFound") {
                     continue;
                 }
@@ -33,16 +36,22 @@ namespace bookTrackerApi.Upgrades {
 
 
 
-        public static string ScriptFinder(string? title) {
+        public static string ScriptFinder(string? title, Boolean runScript) {
 
             string pathToLog;
 
             switch (title) {
                 case "Test upgrade script":
-                    pathToLog = "path/to/log";
+                    if (!runScript) {
+                        return "found";
+                    }
+                    pathToLog = "external/log/log.txt";
                     break;
                 case "A different upgrade script":
-                    pathToLog = "path/to/log2";
+                    if (!runScript) {
+                        return "found";
+                    }
+                    pathToLog = "external/log/log.txt";
                     break;
                 default:
                     return "notFound";

--- a/Booktracker/Upgrade/EntryPoint.cs
+++ b/Booktracker/Upgrade/EntryPoint.cs
@@ -1,7 +1,9 @@
 namespace bookTrackerApi.Upgrades {
 
     public static class EntryPoint {
-
+        
+        ///<summary>Called on startup. Does the following: Adds missing upgrade rows to the database, finds which ones have not yet run,
+        ///loops through each one that should run, creates backups, runs the upgrade, then documents that it has ran in the database.</summary>
         public static void HandleUpgrades() {
 
             //first, we want to add any new upgrade scripts to the database if there are any.
@@ -35,7 +37,10 @@ namespace bookTrackerApi.Upgrades {
         }
 
 
-
+        ///<summary>Using the upgrade script's title, determines which code to run when performing an upgrade.</summary>
+        ///<param name="title">The title of the upgrade script.</param>
+        ///<param name="runScript">Set to true if the script should actually run if it's found. If 'false', it will
+        ///return 'found' rather than actually running the script.</param>
         public static string ScriptFinder(string? title, Boolean runScript) {
 
             string pathToLog;

--- a/Booktracker/Upgrade/EntryPoint.cs
+++ b/Booktracker/Upgrade/EntryPoint.cs
@@ -1,0 +1,21 @@
+namespace bookTrackerApi.Upgrades {
+
+    public static class EntryPoint {
+
+        public static void HandleUpgrades() {
+
+            //first, we want to add any new upgrade scripts to the database if there are any.
+            ScriptDatabaseUpdater.AddMissingRows();
+
+            //get the scripts that have not ran
+
+            
+            //for each one, do the following:
+            //  1. Create a backup of the database and return the path
+            //  2. Call the method that maps a script ID to a script entry point. This should return a path to the log file.
+            //  3. Update the row with dateTime, log path, backup path, etc. 
+        }
+
+    }
+
+}

--- a/Booktracker/Upgrade/EntryPoint.cs
+++ b/Booktracker/Upgrade/EntryPoint.cs
@@ -8,12 +8,47 @@ namespace bookTrackerApi.Upgrades {
             ScriptDatabaseUpdater.AddMissingRows();
 
             //get the scripts that have not ran
+            List<UpgradeTypes.ScriptsToRun> scriptsToRun = Utilities.FindScriptsToRun();
 
+            foreach (UpgradeTypes.ScriptsToRun script in scriptsToRun) {
+
+                if (script == null) {
+                    continue;
+                }
+                string? backupPath = Utilities.CreateBackup(script);
+
+                string logPath = ScriptFinder(script.Title);
+                if (logPath == "notFound") {
+                    continue;
+                }
+
+                Utilities.MarkComplete(script, backupPath, logPath);
+            }
             
             //for each one, do the following:
             //  1. Create a backup of the database and return the path
             //  2. Call the method that maps a script ID to a script entry point. This should return a path to the log file.
             //  3. Update the row with dateTime, log path, backup path, etc. 
+        }
+
+
+
+        public static string ScriptFinder(string? title) {
+
+            string pathToLog;
+
+            switch (title) {
+                case "Test upgrade script":
+                    pathToLog = "path/to/log";
+                    break;
+                case "A different upgrade script":
+                    pathToLog = "path/to/log2";
+                    break;
+                default:
+                    return "notFound";
+            }
+
+            return pathToLog;
         }
 
     }

--- a/Booktracker/Upgrade/ScriptDatabaseUpdater.cs
+++ b/Booktracker/Upgrade/ScriptDatabaseUpdater.cs
@@ -2,10 +2,12 @@ using Newtonsoft.Json;
 using Microsoft.Data.Sqlite;
 
 namespace bookTrackerApi.Upgrades {
-
+    
+    ///<summary>This class handles all functionality surrounding keeping the upgrade_scripts table up to date.</summary>
     public static class ScriptDatabaseUpdater {
         
-        //Gets all upgrade script rows from the JSON file and returns them. 
+        ///<summary>Gets all upgrade script rows from the JSON file and returns them.</summary>
+        ///<returns>A lislt of upgrade objects containing title, version, and description.</returns>
         public static List<UpgradeTypes.JSONScriptInfo>? GetAllRows() {
 
             List<UpgradeTypes.JSONScriptInfo>? upgradeScripts = new();
@@ -18,8 +20,8 @@ namespace bookTrackerApi.Upgrades {
 
         }
 
-        //Loops through each row pulled from the JSON. Adds it to the database if it doesn't already exist.
-        //This is the main entry point for this class. 
+        ///<summary>This is the main entry point for this class.
+        ///Loops through each row pulled from the JSON. Adds it to the database if it doesn't already exist.</summary>
         public static void AddMissingRows() {
             
             List<UpgradeTypes.JSONScriptInfo>? rows = GetAllRows();
@@ -38,7 +40,8 @@ namespace bookTrackerApi.Upgrades {
 
         }
 
-        //Checks to see if the row exists by searching with version and title.
+        ///<summary>Checks to see if the row exists by searching with version and title.</summary>
+        ///<param name="row">The "row" that we are checking to see already exists in the database.</param>
         public static bool DoesRowExist(UpgradeTypes.JSONScriptInfo row) {
 
             using (SqliteConnection connection = DB.initiateConnection()) {
@@ -56,7 +59,8 @@ namespace bookTrackerApi.Upgrades {
         }
 
 
-        //adds a new row to the database. Includes version, title, and description. 
+        ///<summary>Adds a new row to the database in the 'upgrade_scripts' table. Includes version, title, and description.</summary>
+        ///<param name="row">The row that will be added to the database</param>
         public static void AddRow(UpgradeTypes.JSONScriptInfo row) {
 
             using (SqliteConnection connection = DB.initiateConnection()) {

--- a/Booktracker/Upgrade/ScriptDatabaseUpdater.cs
+++ b/Booktracker/Upgrade/ScriptDatabaseUpdater.cs
@@ -1,0 +1,81 @@
+using Newtonsoft.Json;
+using Microsoft.Data.Sqlite;
+
+namespace bookTrackerApi.Upgrades {
+
+    public static class ScriptDatabaseUpdater {
+        
+        //Gets all upgrade script rows from the JSON file and returns them. 
+        public static List<UpgradeTypes.JSONScriptInfo>? GetAllRows() {
+
+            List<UpgradeTypes.JSONScriptInfo>? upgradeScripts = new();
+
+            string jsonContent = File.ReadAllText("Upgrade/upgrade_scripts.json");
+
+            upgradeScripts = JsonConvert.DeserializeObject<List<UpgradeTypes.JSONScriptInfo>>(jsonContent);
+
+            return upgradeScripts;
+
+        }
+
+        //Loops through each row pulled from the JSON. Adds it to the database if it doesn't already exist.
+        //This is the main entry point for this class. 
+        public static void AddMissingRows() {
+            
+            List<UpgradeTypes.JSONScriptInfo>? rows = GetAllRows();
+
+            if (rows == null) {
+                return;
+            }
+
+            foreach (UpgradeTypes.JSONScriptInfo row in rows) {
+
+                if (!DoesRowExist(row)) {
+                    AddRow(row);
+                }
+
+            }
+
+        }
+
+        //Checks to see if the row exists by searching with version and title.
+        public static bool DoesRowExist(UpgradeTypes.JSONScriptInfo row) {
+
+            using (SqliteConnection connection = DB.initiateConnection()) {
+
+                string sql = "SELECT COUNT(*) FROM upgrade_scripts WHERE version = @version AND title = @title";
+                using (SqliteCommand command = new SqliteCommand(sql, connection)) {
+
+                    command.Parameters.AddWithValue("@version", row.Version);
+                    command.Parameters.AddWithValue("@title", row.Title);
+                    int rowCount = Convert.ToInt32(command.ExecuteScalar());
+
+                    return rowCount > 0;
+                }
+            }
+        }
+
+
+        //adds a new row to the database. Includes version, title, and description. 
+        public static void AddRow(UpgradeTypes.JSONScriptInfo row) {
+
+            using (SqliteConnection connection = DB.initiateConnection()) {
+
+                string sql = "INSERT INTO upgrade_scripts (version, title, description) VALUES (@version, @title, @description)";
+                using (SqliteCommand command = new(sql, connection)) {
+
+                    command.Parameters.AddWithValue("@version", row.Version);
+                    command.Parameters.AddWithValue("@title", row.Title);
+                    command.Parameters.AddWithValue("@description", row.Description);
+                    command.ExecuteNonQuery();
+
+                }
+            }
+
+        }
+
+
+
+    }
+
+}

--- a/Booktracker/Upgrade/UpgradeDB.cs
+++ b/Booktracker/Upgrade/UpgradeDB.cs
@@ -1,0 +1,59 @@
+using Microsoft.Data.Sqlite;
+
+namespace bookTrackerApi.Upgrades {
+
+    public static class UpgradeDB {
+
+        public static List<UpgradeTypes.ScriptInfo> GetAllUpgrades() {
+
+            SqliteConnection connection = DB.initiateConnection();
+            string sql = "SELECT * FROM upgrade_scripts WHERE hasRan = 1";
+            using (SqliteCommand command = new SqliteCommand(sql, connection)) {
+                using (SqliteDataReader reader = command.ExecuteReader()) {
+                    List<UpgradeTypes.ScriptInfo> upgrades = new();
+                    while (reader.Read()) {
+                        UpgradeTypes.ScriptInfo upgrade = new();
+                        upgrade.Id = reader.GetInt32(0);
+                        upgrade.Version = reader.GetString(1);
+                        upgrade.Title = reader.GetString(2);
+                        upgrade.Description = reader.GetString(3);
+                        upgrade.CompletedDateTime = reader.GetString(5);
+                        upgrade.LogPath = reader.GetString(6);
+                        upgrade.BackupPath = reader.GetString(7);
+                        upgrades.Add(upgrade);
+                    }
+                    DB.closeConnection(connection);
+                    return upgrades;
+                }
+            }
+
+        }
+
+        public static UpgradeTypes.ScriptInfo GetUpgradeByID(int id) {
+
+            SqliteConnection connection = DB.initiateConnection();
+            string sql = "SELECT * FROM upgrade_scripts WHERE id = @id";
+            using (SqliteCommand command = new SqliteCommand(sql, connection)) {
+                command.Parameters.AddWithValue("@id", id);
+                using (SqliteDataReader reader = command.ExecuteReader()) {
+                    UpgradeTypes.ScriptInfo upgrade = new();
+                    while (reader.Read()) {
+                        
+                        upgrade.Id = reader.GetInt32(0);
+                        upgrade.Version = reader.GetString(1);
+                        upgrade.Title = reader.GetString(2);
+                        upgrade.Description = reader.GetString(3);
+                        upgrade.CompletedDateTime = reader.GetString(5);
+                        upgrade.LogPath = reader.GetString(6);
+                        upgrade.BackupPath = reader.GetString(7);
+                    }
+                    DB.closeConnection(connection);
+                    return upgrade;
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/Booktracker/Upgrade/UpgradeEndpoints.cs
+++ b/Booktracker/Upgrade/UpgradeEndpoints.cs
@@ -1,0 +1,52 @@
+using MySql.Data.MySqlClient.Replication;
+using Newtonsoft.Json;
+
+namespace bookTrackerApi.Upgrades {
+
+    public static class UpgradeEndpoints {
+
+        public static void Configure(WebApplication app) {
+
+            app.MapGet("/api/settings/upgrades", async (HttpContext context, string sessionKey) => {
+                string? remoteIp = context.Connection.RemoteIpAddress?.ToString();
+                SessionInfo? currentSession = Program.Sessions.Find(s => s.Session == sessionKey);
+                if (currentSession == null) {
+                    ErrorMessage errorMessage = JsonLog.logAndCreateErrorMessage(ErrorMessages.invalid_sessionKey, "challenges_view", null, remoteIp);
+                    return Results.BadRequest(errorMessage);
+                }
+                if (currentSession.IsAdmin == 0) {
+                    ErrorMessage errorMessage = JsonLog.logAndCreateErrorMessage(ErrorMessages.invalid_privileges, "upgrade_view", currentSession, remoteIp);
+                    return Results.Unauthorized();
+                }
+                List<UpgradeTypes.ScriptInfo> upgradeScripts = UpgradeDB.GetAllUpgrades();
+                return Results.Ok(upgradeScripts);
+            });
+
+            app.MapGet("/api/settings/upgrades/{id}", async (HttpContext context, string sessionKey, int id) => {
+                string? remoteIp = context.Connection.RemoteIpAddress?.ToString();
+                SessionInfo? currentSession = Program.Sessions.Find(s => s.Session == sessionKey);
+                if (currentSession == null) {
+                    ErrorMessage errorMessage = JsonLog.logAndCreateErrorMessage(ErrorMessages.invalid_sessionKey, "challenges_view", null, remoteIp);
+                    return Results.BadRequest(errorMessage);
+                }
+                if (currentSession.IsAdmin == 0) {
+                    ErrorMessage errorMessage = JsonLog.logAndCreateErrorMessage(ErrorMessages.invalid_privileges, "upgrade_view", currentSession, remoteIp);
+                    return Results.Unauthorized();
+                }
+                UpgradeTypes.UpgradeInfo response = new();
+                response.ScriptInfo = UpgradeDB.GetUpgradeByID(id);
+                if (response.ScriptInfo.Id == null) {
+                    return Results.NotFound();
+                }
+                long fileSizeInBytes = new FileInfo(response.ScriptInfo.BackupPath).Length;
+                double fileSizeInMB = (double)fileSizeInBytes / (1024 * 1024);
+                response.BackupSize = fileSizeInMB.ToString() + " mb";
+                response.LogText = Utilities.GetLogText(response.ScriptInfo.LogPath);
+                return Results.Ok(response);
+            });
+
+        }
+
+    }
+
+}

--- a/Booktracker/Upgrade/UpgradeTypes.cs
+++ b/Booktracker/Upgrade/UpgradeTypes.cs
@@ -1,0 +1,15 @@
+namespace bookTrackerApi.Upgrades {
+
+    public static class UpgradeTypes {
+
+        public class JSONScriptInfo {
+
+            public string? Version { get; set; }
+            public string? Title { get; set; }
+            public string? Description { get; set; }
+
+        }
+
+    }
+
+}

--- a/Booktracker/Upgrade/UpgradeTypes.cs
+++ b/Booktracker/Upgrade/UpgradeTypes.cs
@@ -2,6 +2,8 @@ namespace bookTrackerApi.Upgrades {
 
     public static class UpgradeTypes {
 
+        ///<summary>This type is associated with the JSON file of upgrades that need to be
+        ///reconciled against the database on startup.</summary>
         public class JSONScriptInfo {
 
             public string? Version { get; set; }
@@ -10,6 +12,8 @@ namespace bookTrackerApi.Upgrades {
 
         }
 
+        ///<summary>Contains most of the information about a given upgrade. Used when returning
+        ///a list of finished upgrades to the user from the API.</summary>
         public class ScriptInfo {
 
             public int? Id { get; set; }
@@ -21,6 +25,8 @@ namespace bookTrackerApi.Upgrades {
             public string? BackupPath { get; set; }
         }
 
+        ///<summary>Used when determining which scripts need to run. Title + Version
+        ///is used to identify the correct code to run when actually doing the ugprade.</summary>
         public class ScriptsToRun {
 
             public int? Id { get; set; }
@@ -28,6 +34,8 @@ namespace bookTrackerApi.Upgrades {
             public string? Version { get; set; }
         }
 
+        ///<summary>Contains the full information about an upgrade including backupSize and the full
+        ///text of the logs.</summary>
         public class UpgradeInfo {
 
             public ScriptInfo? ScriptInfo { get; set; }

--- a/Booktracker/Upgrade/UpgradeTypes.cs
+++ b/Booktracker/Upgrade/UpgradeTypes.cs
@@ -16,7 +16,6 @@ namespace bookTrackerApi.Upgrades {
             public string? Version { get; set; }
             public string? Title { get; set; }
             public string? Description { get; set; }
-            public Boolean HasRan { get; set; }
             public string? CompletedDateTime { get; set; }
             public string? LogPath { get; set; }
             public string? BackupPath { get; set; }
@@ -27,6 +26,14 @@ namespace bookTrackerApi.Upgrades {
             public int? Id { get; set; }
             public string? Title { get; set; }
             public string? Version { get; set; }
+        }
+
+        public class UpgradeInfo {
+
+            public ScriptInfo? ScriptInfo { get; set; }
+            public string? BackupSize { get; set; }
+            public string? LogText { get; set; }
+
         }
 
     }

--- a/Booktracker/Upgrade/UpgradeTypes.cs
+++ b/Booktracker/Upgrade/UpgradeTypes.cs
@@ -10,6 +10,25 @@ namespace bookTrackerApi.Upgrades {
 
         }
 
+        public class ScriptInfo {
+
+            public int? Id { get; set; }
+            public string? Version { get; set; }
+            public string? Title { get; set; }
+            public string? Description { get; set; }
+            public Boolean HasRan { get; set; }
+            public string? CompletedDateTime { get; set; }
+            public string? LogPath { get; set; }
+            public string? BackupPath { get; set; }
+        }
+
+        public class ScriptsToRun {
+
+            public int? Id { get; set; }
+            public string? Title { get; set; }
+            public string? Version { get; set; }
+        }
+
     }
 
 }

--- a/Booktracker/Upgrade/Utilities.cs
+++ b/Booktracker/Upgrade/Utilities.cs
@@ -19,7 +19,7 @@ namespace bookTrackerApi.Upgrades {
             String cleanedPath = path.Replace(":","-");
             File.Copy("external/db/database.db", cleanedPath);
 
-            return path;
+            return cleanedPath;
 
 
         }
@@ -61,6 +61,17 @@ namespace bookTrackerApi.Upgrades {
             command.Parameters.AddWithValue("@backupPath", backupPath);
             command.ExecuteNonQuery();
             DB.closeConnection(connection);
+
+        }
+
+        public static string GetLogText(string path) {
+
+            if (File.Exists(path)) {
+                string fileContent = File.ReadAllText(path);
+                return fileContent;
+            } else {
+                return "This file does not exist.";
+            }
 
         }
 

--- a/Booktracker/Upgrade/Utilities.cs
+++ b/Booktracker/Upgrade/Utilities.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using Microsoft.Data.Sqlite;
+
+namespace bookTrackerApi.Upgrades {
+
+    public static class Utilities {
+
+        public static string? CreateBackup(UpgradeTypes.ScriptsToRun row) {
+
+            if (row.Title == null) {
+                return null;
+            }
+
+            Directory.CreateDirectory("external/db/backups");
+            string dateTime = DateTime.Now.ToString("yyyy-MM-dd h:mm:ss").Replace(" ", "_");
+            string title = row.Title.Replace(" ", "_");
+            string path = $"external/db/backups/{dateTime + "_" + title}.db";
+            Console.WriteLine(path);
+            String cleanedPath = path.Replace(":","-");
+            File.Copy("external/db/database.db", cleanedPath);
+
+            return path;
+
+
+        }
+
+        public static List<UpgradeTypes.ScriptsToRun> FindScriptsToRun() {
+
+            using (SqliteConnection connection = DB.initiateConnection()) {
+
+                string sql = "SELECT id, version, title FROM upgrade_scripts WHERE hasRan = @hasRan";
+                using (SqliteCommand command = new SqliteCommand(sql, connection)) {
+
+                    command.Parameters.AddWithValue("@hasRan", 0);
+                    using (SqliteDataReader reader = command.ExecuteReader()) {
+                        List<UpgradeTypes.ScriptsToRun> rows = new();
+                        while (reader.Read()) {
+                            UpgradeTypes.ScriptsToRun row = new();
+                            row.Id = reader.GetInt32(0);
+                            row.Version = reader.GetString(1);
+                            row.Title = reader.GetString(2);
+                            rows.Add(row);
+                        }
+                        DB.closeConnection(connection);
+                        return rows;
+                    }
+                }
+            }
+
+        }
+
+        public static void MarkComplete(UpgradeTypes.ScriptsToRun script, string? backupPath, string logPath) {
+
+            SqliteConnection connection = DB.initiateConnection();
+            string sql = "UPDATE upgrade_scripts SET hasRan=@hasRan, completedDateTime=@completedDateTime, logPath=@logPath, backupPath=@backupPath WHERE id=@id";
+            SqliteCommand command = new SqliteCommand(sql, connection);
+            command.Parameters.AddWithValue("@id", script.Id);
+            command.Parameters.AddWithValue("@hasRan", 1);
+            command.Parameters.AddWithValue("@completedDateTime", DateTime.Now);
+            command.Parameters.AddWithValue("@logPath", logPath);
+            command.Parameters.AddWithValue("@backupPath", backupPath);
+            command.ExecuteNonQuery();
+            DB.closeConnection(connection);
+
+        }
+
+    }
+
+}

--- a/Booktracker/Upgrade/Utilities.cs
+++ b/Booktracker/Upgrade/Utilities.cs
@@ -4,7 +4,9 @@ using Microsoft.Data.Sqlite;
 namespace bookTrackerApi.Upgrades {
 
     public static class Utilities {
-
+        
+        ///<summary>Creates a backup of the database and stores it in the backupus directory.</summary>
+        ///<returns>The path of the created backup.</returns>
         public static string? CreateBackup(UpgradeTypes.ScriptsToRun row) {
 
             if (row.Title == null) {
@@ -24,6 +26,7 @@ namespace bookTrackerApi.Upgrades {
 
         }
 
+        ///<summary>Finds and returns all scripts that have not yet run.</summary.
         public static List<UpgradeTypes.ScriptsToRun> FindScriptsToRun() {
 
             using (SqliteConnection connection = DB.initiateConnection()) {
@@ -49,6 +52,7 @@ namespace bookTrackerApi.Upgrades {
 
         }
 
+        ///<summary>Marks a given script as ran in the database. Fills in completion date/time, log path, backup path.</summary>
         public static void MarkComplete(UpgradeTypes.ScriptsToRun script, string? backupPath, string logPath) {
 
             SqliteConnection connection = DB.initiateConnection();
@@ -64,6 +68,7 @@ namespace bookTrackerApi.Upgrades {
 
         }
 
+        ///<summary>For a given path to a text file, returns the text content.</summary>
         public static string GetLogText(string path) {
 
             if (File.Exists(path)) {

--- a/Booktracker/Upgrade/upgrade_scripts.json
+++ b/Booktracker/Upgrade/upgrade_scripts.json
@@ -1,19 +1,3 @@
 [
-    {
-        "Version": "v0.8-beta",
-        "Title": "Test upgrade script",
-        "Description": "This is a test upgrade script that makes sure the functionality works as expected."
-    },
-
-    {
-        "Version": "v0.8-beta",
-        "Title": "A different upgrade script",
-        "Description": "Let's try again to make sure a new one is added."
-    },
-
-    {
-        "Version": "v0.8-beta",
-        "Title": "A different upgrade script with a unique name",
-        "Description": "This is a test upgrade script that makes sure the functionality works as expected."
-    }
+    
 ]

--- a/Booktracker/Upgrade/upgrade_scripts.json
+++ b/Booktracker/Upgrade/upgrade_scripts.json
@@ -9,5 +9,11 @@
         "Version": "v0.8-beta",
         "Title": "A different upgrade script",
         "Description": "Let's try again to make sure a new one is added."
+    },
+
+    {
+        "Version": "v0.8-beta",
+        "Title": "A different upgrade script with a unique name",
+        "Description": "This is a test upgrade script that makes sure the functionality works as expected."
     }
 ]

--- a/Booktracker/Upgrade/upgrade_scripts.json
+++ b/Booktracker/Upgrade/upgrade_scripts.json
@@ -1,0 +1,13 @@
+[
+    {
+        "Version": "v0.8-beta",
+        "Title": "Test upgrade script",
+        "Description": "This is a test upgrade script that makes sure the functionality works as expected."
+    },
+
+    {
+        "Version": "v0.8-beta",
+        "Title": "A different upgrade script",
+        "Description": "Let's try again to make sure a new one is added."
+    }
+]

--- a/Booktracker/init.sql
+++ b/Booktracker/init.sql
@@ -134,7 +134,8 @@ CREATE TABLE IF NOT EXISTS 'upgrade_scripts' (
   'description' TEXT NOT NULL,
   'hasRan' INTEGER NOT NULL DEFAULT 0,
   'completedDateTime' TEXT,
-  'logFile' TEXT
+  'logPath' TEXT,
+  'backupPath' TEXT
 );
 
 CREATE VIEW IF NOT EXISTS book_list2 AS

--- a/Booktracker/init.sql
+++ b/Booktracker/init.sql
@@ -127,6 +127,16 @@ CREATE TABLE IF NOT EXISTS 'progress_updates' (
   FOREIGN KEY ('journalID') REFERENCES 'journal_entries' ('id') ON DELETE SET NULL
 );
 
+CREATE TABLE IF NOT EXISTS 'upgrade_scripts' (
+  'id' INTEGER PRIMARY KEY AUTOINCREMENT,
+  'version' TEXT NOT NULL,
+  'title' TEXT NOT NULL,
+  'description' TEXT NOT NULL,
+  'hasRan' INTEGER NOT NULL DEFAULT 0,
+  'completedDateTime' TEXT,
+  'logFile' TEXT
+);
+
 CREATE VIEW IF NOT EXISTS book_list2 AS
 SELECT
     t1.iduser_books AS iduser_books, 

--- a/Booktracker/wwwroot/settings.html
+++ b/Booktracker/wwwroot/settings.html
@@ -70,7 +70,7 @@
             </div>
           </div>
           <div class="page-body" style="height: 77vh">
-            <div class="container-xl">
+            <div class="container-xl"  style="padding-bottom: 30px !important;">
               <div class="row row-deck row-cards">
                 <div class="col-sm-12" style="width:100%; height: 100%">
                   <div class="card" style="overflow-y: auto">
@@ -138,6 +138,35 @@
                     </div>
                   </div>
                 </div>
+
+
+                <div class="col-sm-12" style="width:100%; height: 100%">
+                  <div class="card" style="overflow-y: auto">
+                    <div class="card-status-start bg-blue"></div>
+                    <div class="card-body" style="height: 100%">
+                        <h3 class="card-title">Upgrade Info</h3>
+                        <div id="tableWrapper">
+                          <table class="table table-vcenter" id="upgradeTable" style="max-width: 900px">
+                            <thead>
+                              <tr>
+                                  <th>ID</th>
+                                  <th>Version</th>
+                                  <th>Title</th>
+                                  <th>Completed Date-Time</th>
+                                  <th>Backup</th>
+                                  
+                              </tr>
+                            </thead>
+                            <tbody id="upgradeTableBody">
+
+                            </tbody>
+                          </table>
+                        </div>
+                    </div>
+                  </div>
+                </div>
+
+
               </div>
             </div>
           </div>

--- a/Booktracker/wwwroot/settings.html
+++ b/Booktracker/wwwroot/settings.html
@@ -144,7 +144,11 @@
                   <div class="card" style="overflow-y: auto">
                     <div class="card-status-start bg-blue"></div>
                     <div class="card-body" style="height: 100%">
-                        <h3 class="card-title">Upgrade Info</h3>
+                        <h3 class="card-title">Upgrade Info <span class="form-help" data-bs-toggle="popover" 
+                          data-bs-placement="top" data-bs-html="true" data-bs-content="<p><b>Upgrades</b> are bits of code
+                             that run after updating to a new version. Usually, they involve updating the database
+                            after the introduction of new functionality.</p>">?</span></h3>
+                        
                         <div id="tableWrapper">
                           <table class="table table-vcenter" id="upgradeTable" style="max-width: 900px">
                             <thead>

--- a/Booktracker/wwwroot/src/settings.js
+++ b/Booktracker/wwwroot/src/settings.js
@@ -177,8 +177,8 @@ upgradeTableHandler();
 
 async function upgradeTableHandler() {
   let rows = await getUpgradeData();
-  if (rows.length == 0) {
-    document.getElementById("tableWrapper").innerHTML = '<code>No upgrades scripts have ran.</code>'
+  if (rows == "unauthorized" || rows.length == 0) {
+    document.getElementById("tableWrapper").innerHTML = '<code>No upgrades scripts found. Reminder: Admin privileges are required to view upgrades scripts.</code>'
     return;
   }
   for (let i = 0; i < rows.length; i++) {
@@ -194,6 +194,9 @@ async function getUpgradeData() {
           method: 'GET',
       })
       .then(response => {
+          if (response.status == 401) {
+            return "unauthorized"
+          }
           return response.json()
       })
       .then(data => {

--- a/Booktracker/wwwroot/src/settings.js
+++ b/Booktracker/wwwroot/src/settings.js
@@ -102,3 +102,102 @@ function updateLoggingLevel() {
     .then(data => console.log(data))
     .catch(error => console.error(error));
 }
+
+
+class UpgradeRow {
+  id;
+  version;
+  title;
+  dateTime;
+  backupStatus = false;
+  row;
+
+  constructor(response) {
+    this.id = response.id;
+    this.version = response.version;
+    this.title = response.title;
+    this.dateTime = this.formatDateTime(response.completedDateTime);
+
+    if (response.backupPath != null) {
+      this.backupStatus = true;
+    }
+
+    this.buildRow()
+
+  }
+
+  formatDateTime(dateTime) {
+
+    //dateTime = dateTime.replace(/-/g, '/');
+    dateTime = dateTime.split(".")
+
+    return dateTime[0]
+
+  }
+
+  buildRow() {
+
+    let row = document.createElement("tr");
+    row.style.fontSize = "11pt"
+
+    let id = document.createElement("td");
+    id.innerText = this.id;
+    row.append(id);
+
+    let version = document.createElement("td");
+    let versionContent = document.createElement("code");
+    versionContent.innerText = this.version;
+    version.append(versionContent);
+    row.append(version);
+    
+    let title = document.createElement("td");
+    title.innerHTML = `<a href="upgradeDetails.html?id=${this.id}">${this.title}</a>`
+    row.append(title)
+
+    let dateTime = document.createElement("td");
+    dateTime.innerText = this.dateTime;
+    row.append(dateTime);
+
+    let backupData = document.createElement("td");
+    let badge = document.createElement("span");
+    badge.classList.add("badge", "bg-green-lt");
+    badge.innerText = "Successful";
+    if (this.backupStatus == true) {
+      backupData.append(badge);
+    }
+
+    row.append(backupData);
+
+    this.row = row;
+    
+  }
+}
+
+upgradeTableHandler();
+
+async function upgradeTableHandler() {
+  let rows = await getUpgradeData();
+  if (rows.length == 0) {
+    document.getElementById("tableWrapper").innerHTML = '<code>No upgrades scripts have ran.</code>'
+    return;
+  }
+  for (let i = 0; i < rows.length; i++) {
+    let rowObject = new UpgradeRow(rows[i]);
+    document.getElementById("upgradeTableBody").append(rowObject.row);
+  }
+}
+
+async function getUpgradeData() {
+  let sessionKey = localStorage.getItem("sessionKey");
+      
+      return fetch(`/api/settings/upgrades?sessionKey=${sessionKey}`, {
+          method: 'GET',
+      })
+      .then(response => {
+          return response.json()
+      })
+      .then(data => {
+        return data;
+      })
+      .catch(error => console.error(error));
+}

--- a/Booktracker/wwwroot/src/upgradeDetails.js
+++ b/Booktracker/wwwroot/src/upgradeDetails.js
@@ -1,0 +1,44 @@
+handleUpgradeDetails();
+
+function getUpgradeIDFromURL() {
+    let urlParams = new URLSearchParams(window.location.search);
+    upgradeID = urlParams.get('id');
+    
+    return upgradeID
+}
+
+async function handleUpgradeDetails() {
+    let id = getUpgradeIDFromURL();
+    let data = await getUpgradeData(id);
+    displayData(data);
+    
+}
+
+async function getUpgradeData(id) {
+    let sessionKey = localStorage.getItem("sessionKey");
+      
+        return fetch(`/api/settings/upgrades/${id}?sessionKey=${sessionKey}`, {
+          method: 'GET',
+      })
+      .then(response => {
+          if (response.status === 401) {
+              console.log("error");
+          }
+          //console.log("TEST");
+          return response.json()
+      })
+      .then(data => {
+        return data;
+      })
+      .catch(error => console.error(error));
+}
+
+function displayData(data) {
+    document.getElementById("upgradeTitle").innerText = data.scriptInfo.title;
+    document.getElementById("upgradeVersion").innerText = data.scriptInfo.version;
+    document.getElementById("backupSize").innerText = data.backupSize;
+    document.getElementById("backupPath").innerText = data.scriptInfo.backupPath
+    document.getElementById("upgradeDescription").innerText = data.scriptInfo.description;
+    document.getElementById("logs").innerText = data.logText;
+    document.getElementById("logPath").innerText = data.scriptInfo.logPath;
+}

--- a/Booktracker/wwwroot/upgradeDetails.html
+++ b/Booktracker/wwwroot/upgradeDetails.html
@@ -77,11 +77,14 @@
                     <div class="card-status-start bg-blue"></div>
                     <div class="card-body" style="height: 100%">
                         <div>
-                            <h3 class="card-title">Info</h3>
-                            <p><b>Title:</b> <span id="upgradeTitle"></span></p>
-                            <p><b>Version:</b> <code id="upgradeVersion"></code></p>
-                            <p><b>Backup:</b> <code id="backupSize"></code> at <code id="backupPath"></code></code></p>
-                            <p><b>Description:</b> <span id="upgradeDescription"></span></p>
+                            <div style="display: flex; gap: 15px; align-items: flex-start">
+                                <span class="badge bg-gray" style="margin-top: 4px" id="upgradeVersion"></span>
+                                <h3 class="card-title" id="upgradeTitle">Info </h3>
+                                
+                            </div>
+                            <p id="upgradeDescription"></p>
+                            <p><b>Database Backup:</b> <code id="backupSize"></code> at <code id="backupPath"></code></code></p>
+                            
                         </div>
                     </div>
                   </div>

--- a/Booktracker/wwwroot/upgradeDetails.html
+++ b/Booktracker/wwwroot/upgradeDetails.html
@@ -1,0 +1,121 @@
+<html>
+    <body>
+        <link rel="stylesheet" href="styles/styles.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta17/dist/css/tabler.min.css">
+        <link href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta17/dist/libs/dropzone/dist/dropzone.css" rel="stylesheet" />
+    </body>
+
+    <div class="page">
+        <!-- Sidebar -->
+        <header class="navbar navbar-expand-sm navbar-light d-print-none">
+          <div class="container-xl" id="test">
+            <h1 class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pe-0 pe-md-3">
+              <a href="index.html">
+                Book Tracker
+              </a>
+            </h1>
+      
+            <div class="navbar-nav flex-row order-md-last">
+              <div class="nav-item">
+                  <div>
+                    <a class="btn" href="search.html">Add New Book</a>
+                    <button class="btn" onclick="logOut()">Log Out</button>
+                  </div>
+              </div>
+            </div>
+          </div>
+        </header>
+        <header class="navbar navbar-expand-sm navbar-light d-print-none" style="max-height: 56px">
+          <div class="container-xl">
+            <div class="nav nav-tabs border-0 flex-column flex-lg-row menuTest" style="flex-wrap: nowrap;">
+              <a class="nav-itemMenu" href="index.html">Home</a>
+              <a class="nav-itemMenu" href="booklist.html">My Books</a>
+              <div class="dropdown" style="height: 48px !important">
+                <a class="nav-itemMenu dropdown-toggle" data-bs-toggle="dropdown">Collections</a>
+                <div class="dropdown-menu">
+                  <a class="dropdown-item" href="collections.html">Collections Home</a>
+                  <a class="dropdown-item" href="addNewCollection.html">Add New Collection</a>
+                </div>
+              </div>
+              <div class="dropdown" style="height: 48px !important">
+                <a class="nav-itemMenu dropdown-toggle" data-bs-toggle="dropdown">Challenges</a>
+                <div class="dropdown-menu">
+                  <a class="dropdown-item" href="challenges.html">Challenges Home</a>
+                  <a class="dropdown-item" href="challengeBuilder.html">Add New Challenge</a>
+                </div>
+              </div>
+              <a class="nav-itemMenu" href="statistics.html">Statistics</a>
+              <div class="dropdown" style="height: 48px !important">
+                <a class="nav-itemMenu dropdown-toggle" data-bs-toggle="dropdown">Settings</a>
+                <div class="dropdown-menu">
+                  <a class="dropdown-item" href="settings.html">Settings</a>
+                  <a class="dropdown-item" href="books.html">Main Book Database</a>
+                  <a class="dropdown-item" href="users.html">User Management</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+        <div class="page-wrapper">
+          <div class="page-header d-print-none">
+            <div class="container-xl">
+              <div class="row g-2 align-items-center">
+                <div class="col" id="titleColumn">
+                  <h2 class="page-title">
+                    Upgrade Details
+                  </h2>
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="page-body" style="height: 77vh">
+            <div class="container-xl"  style="padding-bottom: 30px !important;">
+              <div class="row row-deck row-cards">
+                <div class="col-sm-12" style="width:100%; height: 100%">
+                  <div class="card" style="overflow-y: auto">
+                    <div class="card-status-start bg-blue"></div>
+                    <div class="card-body" style="height: 100%">
+                        <div>
+                            <h3 class="card-title">Info</h3>
+                            <p><b>Title:</b> <span id="upgradeTitle"></span></p>
+                            <p><b>Version:</b> <code id="upgradeVersion"></code></p>
+                            <p><b>Backup:</b> <code id="backupSize"></code> at <code id="backupPath"></code></code></p>
+                            <p><b>Description:</b> <span id="upgradeDescription"></span></p>
+                        </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="col-sm-12" style="width:100%; height: 100%">
+                    <div class="card" style="overflow-y: auto">
+                      <div class="card-status-start bg-blue"></div>
+                      <div class="card-body" style="height: 100%">
+                          <h3 class="card-title">Upgrade Logs</h3>
+                          <p>Log file is stored at <code id="logPath"></code>.</p>
+                          <div class="codeBlock" style="width: 100%; background-color: #f1f5f9; min-height: 100px; padding: 25px;">
+                            <code id="logs">
+                                
+                            </code>
+                          </div>
+                      </div>
+                    </div>
+                </div>
+                
+                
+
+
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      
+
+    <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta17/dist/js/tabler.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta17/dist/libs/dropzone/dist/dropzone-min.js"></script>
+    <script src="src/checkAuth.js"></script>
+    <script src="src/upgradeDetails.js"></script>
+    
+</html>


### PR DESCRIPTION
This pull request merges upgrade-scripts branch into develop.

upgrade-scripts introduces the concept of "upgrades" into Booktracker, which are bits of code that run one time after an update as a way to ensure the database is up to date for new functionality introduced in each update.

For example, an upcoming Booktracker release will introduce functionality to track authors. This will require a change to the books table in the SQLite database as well as an update to all existing rows within it. The change will be reflected in the init.sql file that new users will run when the database first initializes, but an upgrade script will ensure that the table for existing users will also undergo the necessary change for this new feature.

On the client side, upgrade scripts are seen by users with admin privileges from the Settings page. Users can view the logs generated by the update, find the path to the automatic database backup, and more from a detailed Upgrade Details page.